### PR TITLE
Targeting lower versions of netstandard and netframework

### DIFF
--- a/ConfigurationSubstitution.Tests/ConfigurationSubstitution.Tests.csproj
+++ b/ConfigurationSubstitution.Tests/ConfigurationSubstitution.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
-		<Nullable>enable</Nullable>
+		<TargetFramework>net472</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
+++ b/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-	<Nullable>enable</Nullable>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	<PackageId>ConfigurationSubstitutor</PackageId>
-	<Authors>molinch</Authors>
-	<Company>Fabien Molinet</Company>
-	<Product>ConfigurationSubstitutor</Product>
-	<Description>Allows to substitute variables from configuration, this way hostnames, or passwords can be separated and automatically substituted if another configuration entry references them.
-Scenarios could be that you have the password from an Azure KeyVault and the connection string defined in appsettings. The connection string can reference the password.
-Another scenario is that you have multiple configuration entries for the same domain, don't duplicate that information anymore, reference it.</Description>
-	<PackageLicenseFile>LICENSE</PackageLicenseFile>
-	<PackageIcon>logo.png</PackageIcon>
-	<RepositoryUrl>https://github.com/molinch/ConfigurationSubstitutor</RepositoryUrl>
-	<RepositoryType>GitHub</RepositoryType>
-	<PackageProjectUrl>https://github.com/molinch/ConfigurationSubstitutor</PackageProjectUrl>
-	<PackageTags>netcore options configuration substitute substitution substituted variable aspnet</PackageTags>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageId>ConfigurationSubstitutor</PackageId>
+    <Authors>molinch</Authors>
+    <Company>Fabien Molinet</Company>
+    <Product>ConfigurationSubstitutor</Product>
+    <Description>
+      Allows to substitute variables from configuration, this way hostnames, or passwords can be separated and automatically substituted if another configuration entry references them.
+      Scenarios could be that you have the password from an Azure KeyVault and the connection string defined in appsettings. The connection string can reference the password.
+      Another scenario is that you have multiple configuration entries for the same domain, don't duplicate that information anymore, reference it.
+    </Description>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageIcon>logo.png</PackageIcon>
+    <RepositoryUrl>https://github.com/molinch/ConfigurationSubstitutor</RepositoryUrl>
+    <RepositoryType>GitHub</RepositoryType>
+    <PackageProjectUrl>https://github.com/molinch/ConfigurationSubstitutor</PackageProjectUrl>
+    <PackageTags>netcore options configuration substitute substitution substituted variable aspnet</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Are you open to a PR that lowers the netstandard and netframework versions from 2.1 to 2.0 and 5.0 to 4.7.2 respectively? I'd like to use this on a project that requires these. From what I can tell, the project doesn't currently make use of any new features in either, so this change would only serve to increase compatibility.