### PR TITLE
9 net6 support

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET6
 
 on:
   push:
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.302
+        dotnet-version: 6.0
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0
+        dotnet-version: 6.0.*
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0
+        dotnet-version: 6.0.*
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET6
 
 on:
   push:
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.302
+        dotnet-version: 6.0
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/ConfigurationSubstitution.Tests/ConfigurationSubstitution.Tests.csproj
+++ b/ConfigurationSubstitution.Tests/ConfigurationSubstitution.Tests.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6</TargetFramework>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="5.10.3" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.6" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+		<PackageReference Include="FluentAssertions" Version="6.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="1.3.0">
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/ConfigurationSubstitution.Tests/ConfigurationTests.cs
+++ b/ConfigurationSubstitution.Tests/ConfigurationTests.cs
@@ -8,10 +8,19 @@ namespace ConfigurationSubstitution.Tests
 {
     public class ConfigurationTests
     {
-        [Fact]
-        public void Should_get_substituted_value_when_substitution_is_in_middle()
+        public delegate IConfigurationBuilder ConfigurationBuilderGenerator();
+        public static TheoryData<ConfigurationBuilderGenerator> ConfigurationBuilderTheoryData
+            = new()
+            {
+                () => new ConfigurationBuilder(),
+                () => new ConfigurationManager()
+            };
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_substitution_is_in_middle(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "ConnectionString", "blablabla&password={DatabasePassword}&server=localhost" },
@@ -27,10 +36,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("blablabla&password=ComplicatedPassword&server=localhost");
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_substitution_is_first()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_substitution_is_first(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "ConnectionString", "{DatabasePassword}&server=localhost" },
@@ -46,10 +56,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("ComplicatedPassword&server=localhost");
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_substitution_is_last()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_substitution_is_last(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "ConnectionString", "blablabla&password={DatabasePassword}" },
@@ -65,10 +76,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("blablabla&password=ComplicatedPassword");
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_multiple_substitutions()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_multiple_substitutions(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "{Bar1}{Bar2}{Bar1}" },
@@ -85,10 +97,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Barista-Jean-Barista");
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_nested()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_nested(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "{Bar1}" },
@@ -105,10 +118,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("-Jean-");
         }
 
-        [Fact]
-        public void Should_throw_exception_when_recursive()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_throw_exception_when_recursive(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "{Bar1}" },
@@ -124,10 +138,11 @@ namespace ConfigurationSubstitution.Tests
             func.Should().Throw<EndlessRecursionVariableException>();
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_different_start_end()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_different_start_end(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "yolo $(Bar) what's up?" },
@@ -143,10 +158,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("yolo boy what's up?");
         }
 
-        [Fact]
-        public void Should_get_non_substituted_value_as_is()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_non_substituted_value_as_is(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Bar", "Boyz n the hood" }
@@ -161,10 +177,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Boyz n the hood");
         }
 
-        [Fact]
-        public void Should_throw_for_non_resolved_variable()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_throw_for_non_resolved_variable(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     { "TestKey", "Test value {Foobar}" }
@@ -179,10 +196,11 @@ namespace ConfigurationSubstitution.Tests
             act.Should().Throw<UndefinedConfigVariableException>().WithMessage("*variable*{Foobar}*");
         }
 
-        [Fact]
-        public void Should_ignore_non_resolved_variable()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_ignore_non_resolved_variable(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     { "TestKey", "Test value {Foobar}" }
@@ -195,10 +213,12 @@ namespace ConfigurationSubstitution.Tests
             value.Should().Be("Test value ");
         }
 
-        [Fact] // covers https://github.com/molinch/ConfigurationSubstitutor/issues/4
-        public void Should_get_substituted_value_when_multiple_matches_present()
+
+        [Theory] // covers https://github.com/molinch/ConfigurationSubstitutor/issues/4
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_multiple_matches_present(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                 { "Foo", "Works with $(Var1) and $(Var2)" },
@@ -215,10 +235,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Works with one and two");
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_using_different_substituable_pattern()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_using_different_substituable_pattern(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                 { "Foo", "Hello <<Var>>" },
@@ -234,10 +255,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Hello world");
         }
 
-        [Fact]
-        public void Should_not_get_substituted_value_when_no_match()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_not_get_substituted_value_when_no_match(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                 { "Foo", "Hello world, nothing to see here" }
@@ -252,10 +274,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Hello world, nothing to see here");
         }
 
-        [Fact]
-        public void Should_not_get_substituted_value_when_not_maching_start_tag()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_not_get_substituted_value_when_not_maching_start_tag(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                 { "Foo", "Hello (world)" }
@@ -270,10 +293,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Hello (world)");
         }
 
-        [Fact]
-        public void Should_not_get_substituted_value_when_no_end_tag()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_not_get_substituted_value_when_no_end_tag(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                 { "Foo", "Hello $(Var what's up ?" }
@@ -288,10 +312,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be("Hello $(Var what's up ?");
         }
 
-        [Fact]
-        public void Should_substitute_variable_when_substituted_value_is_empty()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_substitute_variable_when_substituted_value_is_empty(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "$(Var1)" },
@@ -307,10 +332,11 @@ namespace ConfigurationSubstitution.Tests
             substituted.Should().Be(string.Empty);
         }
 
-        [Fact]
-        public void Should_throw_exception_when_substituted_value_is_null()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_throw_exception_when_substituted_value_is_null(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string?>()
                 {
                     { "Foo", "$(Var1)" },
@@ -326,10 +352,11 @@ namespace ConfigurationSubstitution.Tests
             func.Should().Throw<UndefinedConfigVariableException>();
         }
 
-        [Fact]
-        public void Should_get_substituted_value_when_using_long_substituable_pattern()
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        public void Should_get_substituted_value_when_using_long_substituable_pattern(ConfigurationBuilderGenerator builderGenerator)
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "Hello %(env,Testo)%" },

--- a/ConfigurationSubstitution.Tests/ConfigurationTests.cs
+++ b/ConfigurationSubstitution.Tests/ConfigurationTests.cs
@@ -8,8 +8,7 @@ namespace ConfigurationSubstitution.Tests
 {
     public class ConfigurationTests
     {
-        public delegate IConfigurationBuilder ConfigurationBuilderGenerator();
-        public static TheoryData<ConfigurationBuilderGenerator> ConfigurationBuilderTheoryData
+        public static TheoryData<Func<IConfigurationBuilder>> ConfigurationBuilderTheoryData
             = new()
             {
                 () => new ConfigurationBuilder(),
@@ -18,7 +17,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_substitution_is_in_middle(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_substitution_is_in_middle(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -38,7 +37,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_substitution_is_first(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_substitution_is_first(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -58,7 +57,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_substitution_is_last(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_substitution_is_last(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -78,7 +77,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_multiple_substitutions(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_multiple_substitutions(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -99,7 +98,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_nested(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_nested(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -120,7 +119,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_throw_exception_when_recursive(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_throw_exception_when_recursive(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -140,7 +139,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_different_start_end(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_different_start_end(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -160,7 +159,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_non_substituted_value_as_is(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_non_substituted_value_as_is(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -179,7 +178,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_throw_for_non_resolved_variable(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_throw_for_non_resolved_variable(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>
@@ -198,7 +197,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_ignore_non_resolved_variable(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_ignore_non_resolved_variable(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>
@@ -216,7 +215,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory] // covers https://github.com/molinch/ConfigurationSubstitutor/issues/4
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_multiple_matches_present(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_multiple_matches_present(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -237,7 +236,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_using_different_substituable_pattern(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_using_different_substituable_pattern(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -257,7 +256,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_not_get_substituted_value_when_no_match(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_not_get_substituted_value_when_no_match(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -276,7 +275,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_not_get_substituted_value_when_not_maching_start_tag(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_not_get_substituted_value_when_not_maching_start_tag(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -295,7 +294,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_not_get_substituted_value_when_no_end_tag(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_not_get_substituted_value_when_no_end_tag(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -314,7 +313,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_substitute_variable_when_substituted_value_is_empty(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_substitute_variable_when_substituted_value_is_empty(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
@@ -334,7 +333,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_throw_exception_when_substituted_value_is_null(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_throw_exception_when_substituted_value_is_null(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string?>()
@@ -354,7 +353,7 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_substituted_value_when_using_long_substituable_pattern(ConfigurationBuilderGenerator builderGenerator)
+        public void Should_get_substituted_value_when_using_long_substituable_pattern(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()

--- a/ConfigurationSubstitution.sln
+++ b/ConfigurationSubstitution.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30223.230
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfigurationSubstitution", "ConfigurationSubstitutor\ConfigurationSubstitution.csproj", "{784C352F-3845-48FE-9093-FED35ECE0586}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationSubstitution.Tests", "ConfigurationSubstitution.Tests\ConfigurationSubstitution.Tests.csproj", "{905B5589-D14C-4BD9-82FA-B86E0B371EA8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfigurationSubstitution.Tests", "ConfigurationSubstitution.Tests\ConfigurationSubstitution.Tests.csproj", "{905B5589-D14C-4BD9-82FA-B86E0B371EA8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ConfigurationSubstitutor/ChainedSubstitutedConfigurationProvider.cs
+++ b/ConfigurationSubstitutor/ChainedSubstitutedConfigurationProvider.cs
@@ -12,12 +12,15 @@ namespace ConfigurationSubstitution
         private readonly ConfigurationSubstitutor _substitutor;
 
         /// <summary>
-        /// Initialize a new instance from the configuration.
+        /// Initialize a new instance from the configuration root.
         /// </summary>
-        /// <param name="config">The configuration.</param>
-        public ChainedSubstitutedConfigurationProvider(IConfiguration config, ConfigurationSubstitutor substitutor)
+        /// <param name="root">The configuration root.</param>
+        /// <param name="substitutor">Configuration substitutor</param>
+        public ChainedSubstitutedConfigurationProvider(
+            IConfigurationRoot root,
+            ConfigurationSubstitutor substitutor)
         {
-            _config = config;
+            _config = new ChainedSubstitutedConfigurationRoot(root);
             _substitutor = substitutor;
         }
 

--- a/ConfigurationSubstitutor/ChainedSubstitutedConfigurationRoot.cs
+++ b/ConfigurationSubstitutor/ChainedSubstitutedConfigurationRoot.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConfigurationSubstitution
+{
+    /// <summary>
+    /// Proxy configuration root that filters out <see cref="ChainedSubstitutedConfigurationProvider"/>
+    /// from the given providers
+    /// </summary>
+    internal class ChainedSubstitutedConfigurationRoot : IConfigurationRoot
+    {
+        private readonly Lazy<ConfigurationRoot> _root;
+
+        public ChainedSubstitutedConfigurationRoot(IConfigurationRoot root)
+        {
+            _root = new Lazy<ConfigurationRoot>(() =>
+            {
+                var filteredProviders = root.Providers?
+                    .Where(p => p.GetType() != typeof(ChainedSubstitutedConfigurationProvider))
+                    .ToList();
+                return new ConfigurationRoot(filteredProviders);
+            });
+        }
+        
+
+        public IConfigurationSection GetSection(string key) => _root.Value.GetSection(key);
+
+        public IEnumerable<IConfigurationSection> GetChildren() => _root.Value.GetChildren();
+
+        public IChangeToken GetReloadToken() => _root.Value.GetReloadToken();
+
+        public string this[string key]
+        {
+            get => _root.Value[key];
+            set => _root.Value[key] = value;
+        }
+
+        public void Reload() => _root.Value.Reload();
+
+        public IEnumerable<IConfigurationProvider> Providers => _root.Value.Providers;
+    }
+}

--- a/ConfigurationSubstitutor/ChainedSubstitutedConfigurationSource.cs
+++ b/ConfigurationSubstitutor/ChainedSubstitutedConfigurationSource.cs
@@ -8,12 +8,12 @@ namespace ConfigurationSubstitution
     public class ChainedSubstitutedConfigurationSource : IConfigurationSource
     {
         private readonly ConfigurationSubstitutor _substitutor;
-        private readonly IConfiguration _configuration;
+        private readonly IConfigurationRoot _root;
 
-        public ChainedSubstitutedConfigurationSource(ConfigurationSubstitutor substitutor, IConfiguration configuration)
+        public ChainedSubstitutedConfigurationSource(ConfigurationSubstitutor substitutor, IConfigurationRoot root)
         {
             _substitutor = substitutor;
-            _configuration = configuration;
+            _root = root;
         }
 
         /// <summary>
@@ -22,6 +22,6 @@ namespace ConfigurationSubstitution
         /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>
         /// <returns>A <see cref="ChainedSubstitutedConfigurationProvider"/></returns>
         public IConfigurationProvider Build(IConfigurationBuilder builder)
-            => new ChainedSubstitutedConfigurationProvider(_configuration, _substitutor);
+            => new ChainedSubstitutedConfigurationProvider(_root, _substitutor);
     }
 }

--- a/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
+++ b/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
@@ -24,7 +24,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
+++ b/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageId>ConfigurationSubstitutor</PackageId>
     <Authors>molinch</Authors>
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.6" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
+++ b/ConfigurationSubstitutor/ConfigurationSubstitution.csproj
@@ -18,7 +18,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <PackageProjectUrl>https://github.com/molinch/ConfigurationSubstitutor</PackageProjectUrl>
     <PackageTags>netcore options configuration substitute substitution substituted variable aspnet</PackageTags>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
+++ b/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
@@ -14,9 +14,7 @@ namespace ConfigurationSubstitution
             return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables));
         }
 
-        private static IConfigurationBuilder EnableSubstitutions(
-            this IConfigurationBuilder builder,
-            ConfigurationSubstitutor substitutor)
+        private static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder,ConfigurationSubstitutor substitutor)
         {
             return builder.Add(new ChainedSubstitutedConfigurationSource(substitutor, builder.Build()));
         }

--- a/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
+++ b/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
@@ -14,7 +14,9 @@ namespace ConfigurationSubstitution
             return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables));
         }
 
-        private static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, ConfigurationSubstitutor substitutor)
+        private static IConfigurationBuilder EnableSubstitutions(
+            this IConfigurationBuilder builder,
+            ConfigurationSubstitutor substitutor)
         {
             return builder.Add(new ChainedSubstitutedConfigurationSource(substitutor, builder.Build()));
         }

--- a/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
+++ b/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace ConfigurationSubstitution
             return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables));
         }
 
-        private static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder,ConfigurationSubstitutor substitutor)
+        private static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, ConfigurationSubstitutor substitutor)
         {
             return builder.Add(new ChainedSubstitutedConfigurationSource(substitutor, builder.Build()));
         }


### PR DESCRIPTION
Addresses #9, Net 6 Support

When targeting .Net 6, the new  `ConfigurationManager` is used as implementation for both `IConfigurationBuilder` and  `IConfigurationRoot`. So on `ConfigurationManager.Build()` it returns itself, which causes issues with the current implementation of **ConfigurationSubstitutor**.

This PR introduces a proxy `ChainedSubstitutedConfigurationRoot` that mainly creates a new `ConfigurationRoot` instance by removing the `ChainedSubstitutedConfigurationProvider` to avoid recursion.
