### PR TITLE
Add support for default fallback values

### DIFF
--- a/ConfigurationSubstitution.Tests/ConfigurationTests.cs
+++ b/ConfigurationSubstitution.Tests/ConfigurationTests.cs
@@ -497,7 +497,7 @@ namespace ConfigurationSubstitution.Tests
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
-                    { "Foo", "$(Var1:Val1:Val2)" },
+                    { "Foo", "$(Var1:http://example.com)" },
                 })
                 .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":");
 
@@ -506,7 +506,7 @@ namespace ConfigurationSubstitution.Tests
             // Act
             var substituted = configuration["Foo"];
 
-            substituted.Should().Be("Val1");
+            substituted.Should().Be("http://example.com");
 
         }
 

--- a/ConfigurationSubstitutor/ConfigurationSubstitutor.cs
+++ b/ConfigurationSubstitutor/ConfigurationSubstitutor.cs
@@ -68,7 +68,7 @@ namespace ConfigurationSubstitution
 
                 if (substitutedValue == null && !string.IsNullOrEmpty(_fallbackDefaultValueDelimiter))
                 {
-                    var delimitedVals = capture.Value.Split(new[] { _fallbackDefaultValueDelimiter }, StringSplitOptions.None);
+                    var delimitedVals = capture.Value.Split(new[] { _fallbackDefaultValueDelimiter }, 2, StringSplitOptions.None);
                     // in case delimiter doesn't match
                     if (delimitedVals.Length < 2)
                     {

--- a/ConfigurationSubstitutor/ConfigurationSubstitutor.cs
+++ b/ConfigurationSubstitutor/ConfigurationSubstitutor.cs
@@ -24,9 +24,12 @@ namespace ConfigurationSubstitution
 
         public ConfigurationSubstitutor(string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables = true, string fallbackDefaultValueDelimiter = "")
         {
-            _startsWith = substitutableStartsWith;
-            _endsWith = substitutableEndsWith;
-            _fallbackDefaultValueDelimiter = fallbackDefaultValueDelimiter;
+            _startsWith = !String.IsNullOrEmpty(substitutableStartsWith) ? substitutableStartsWith : throw new ArgumentException(
+                $"Invalid substitutableStartsWith value", nameof(substitutableStartsWith));
+            _endsWith = !String.IsNullOrEmpty(substitutableEndsWith) ? substitutableEndsWith : throw new ArgumentException(
+                $"Invalid substitutableEndsWith value", nameof(substitutableEndsWith));
+            _fallbackDefaultValueDelimiter = fallbackDefaultValueDelimiter ?? throw new ArgumentNullException(
+                nameof(fallbackDefaultValueDelimiter), $"Invalid fallbackDefaultValueDelimiter value");
             var escapedStart = Regex.Escape(_startsWith);
             var escapedEnd = Regex.Escape(_endsWith);
 

--- a/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
+++ b/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
@@ -18,5 +18,10 @@ namespace ConfigurationSubstitution
         {
             return builder.Add(new ChainedSubstitutedConfigurationSource(substitutor, builder.Build()));
         }
+
+        public static IConfigurationBuilder EnableSubstitutionsWithDelimitedFallbackDefaults(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, string fallbackDefaultValueDelimiter, bool exceptionOnMissingVariables = true)
+        {
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, fallbackDefaultValueDelimiter));
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 		});
 ```
 
+Moreover, you can also provide an in-line default value to fallback on in case a variable is missing, using the `EnableSubstitutionsWithDelimitedFallbackDefaults`. In such case, the delimiter string separating the variable name from the fallback default value must be provided (can't be `null` or empty).
+
+```c#
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+	Host.CreateDefaultBuilder(args)
+		.ConfigureAppConfiguration((ctx, builder) =>
+		{
+			// if you have any additional configuration place it before
+			builder.EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":");
+		});
+```
 
 ## Examples
 
@@ -62,7 +73,7 @@ Easy-peasy `substituted` contains `blablabla&password=ComplicatedPassword&server
 
 ### More substitutions
 It supports any number of substitutions, for example if the configuration contains these three entries:
-- Foo = {Bar1}{Bar2}{Bar1}
+- Foo = {Bar1}{Bar2}{Bar1}{Bar3:-Doe}
 - Bar1 = Barista
 - Bar2 = -Jean-
 
@@ -70,4 +81,4 @@ It supports any number of substitutions, for example if the configuration contai
 var substituted = configuration["Foo"];
 ```
 
-Now `substituted` contains `Barista-Jean-Barista`
+Now `substituted` contains `Barista-Jean-Barista-Doe`


### PR DESCRIPTION
Addresses #11, to add support for fallback default values for variables

Providing values for all variables can be cumbersome at times when there are many of them. This feature is meant to allow users to pass in a default value to fall back on in case the user doesn't provide one, all specified in the same config file. 

To preserve backwards compatibility, a new method `EnableSubstitutionsWithDelimitedFallbackDefaults`, allows specifying a delimiter that separates the variable from the fallback default value.