### PR TITLE
Keep raw settings on missing variable

### DIFF
--- a/ConfigurationSubstitution.Tests/ConfigurationTests.cs
+++ b/ConfigurationSubstitution.Tests/ConfigurationTests.cs
@@ -15,6 +15,750 @@ namespace ConfigurationSubstitution.Tests
                 () => new ConfigurationManager()
             };
 
+        #region Obsolete method tests
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_substitution_is_in_middle_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "ConnectionString", "blablabla&password={DatabasePassword}&server=localhost" },
+                    { "DatabasePassword", "ComplicatedPassword" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["ConnectionString"];
+
+            substituted.Should().Be("blablabla&password=ComplicatedPassword&server=localhost");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_substitution_is_first_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "ConnectionString", "{DatabasePassword}&server=localhost" },
+                    { "DatabasePassword", "ComplicatedPassword" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["ConnectionString"];
+
+            substituted.Should().Be("ComplicatedPassword&server=localhost");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_substitution_is_last_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "ConnectionString", "blablabla&password={DatabasePassword}" },
+                    { "DatabasePassword", "ComplicatedPassword" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["ConnectionString"];
+
+            substituted.Should().Be("blablabla&password=ComplicatedPassword");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_multiple_substitutions_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "{Bar1}{Bar2}{Bar1}" },
+                    { "Bar1", "Barista" },
+                    { "Bar2", "-Jean-" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Barista-Jean-Barista");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_nested_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "{Bar1}" },
+                    { "Bar1", "{Bar2}" },
+                    { "Bar2", "-Jean-" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("-Jean-");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_nested_with_fallback_default_values_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "{Bar1:default_value_1}" },
+                    { "Bar1", "{Bar2:default_value_2}" },
+                    { "Bar2", "-Jean-" }
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("{", "}", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("-Jean-");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_recursive_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            Action act1 = () =>
+            {
+                var configurationBuilder = builderGenerator()
+                    .AddInMemoryCollection(new Dictionary<string, string>()
+                    {
+                        { "Foo", "{Bar1}" },
+                        { "Bar1", "{Foo}" },
+                    })
+                    .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+                var configuration = configurationBuilder.Build();
+
+                var substituted = configuration["Foo"];
+            };
+
+            // Act & assert
+            act1.Should().Throw<EndlessRecursionVariableException>();
+
+            Action act2 = () =>
+            {
+                var configurationBuilder = builderGenerator()
+                    .AddInMemoryCollection(new Dictionary<string, string>()
+                    {
+                        { "Foo", "{Bar1:default_value}" },
+                        { "Bar1", "{Foo}" },
+                    })
+                    .EnableSubstitutionsWithDelimitedFallbackDefaults("{", "}", ":", exceptionOnMissingVariables: true);
+
+                var configuration = configurationBuilder.Build();
+
+                var substituted = configuration["Foo"];
+            };
+
+            // Act & assert
+            act2.Should().Throw<EndlessRecursionVariableException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_different_start_end_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "yolo $(Bar) what's up?" },
+                    { "Bar", "boy" }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("yolo boy what's up?");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_non_substituted_value_as_is_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Bar", "Boyz n the hood" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Bar"];
+
+            substituted.Should().Be("Boyz n the hood");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_for_non_resolved_variable_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestKey", "Test value {Foobar}" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            Action act = () => _ = configuration["TestKey"];
+
+            act.Should().Throw<UndefinedConfigVariableException>().WithMessage("*variable*{Foobar}*");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_for_non_resolved_variable_and_mismatch_fallback_default_value_delimiter_on_deprecated(
+            Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestKey", "Test value {Foobar}" }
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("{", "}", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            Action act = () => _ = configuration["TestKey"];
+
+            act.Should().Throw<UndefinedConfigVariableException>().WithMessage("*variable*{Foobar}*");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_ignore_non_resolved_variable_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestKey", "Test value {Foobar}" }
+                })
+                .EnableSubstitutions(exceptionOnMissingVariables: false);
+
+            var configuration = configurationBuilder.Build();
+
+            var value = configuration["TestKey"];
+            value.Should().Be("Test value ");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_ignore_non_resolved_variable_and_mismatch_fallback_default_value_delimiter_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestKey", "Test value {Foobar}" }
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("{", "}", ":", false);
+
+            var configuration = configurationBuilder.Build();
+
+            var value = configuration["TestKey"];
+            value.Should().Be("Test value ");
+        }
+
+        [Theory] // covers https://github.com/molinch/ConfigurationSubstitutor/issues/4
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_multiple_matches_present_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                { "Foo", "Works with $(Var1) and $(Var2)" },
+                { "Var1", "one" },
+                { "Var2", "two" }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Works with one and two");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_using_different_substituable_pattern_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                { "Foo", "Hello <<Var>>" },
+                { "Var", "world" }
+                })
+                .EnableSubstitutions("<<", ">>", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello world");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_not_get_substituted_value_when_no_match_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                { "Foo", "Hello world, nothing to see here" }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello world, nothing to see here");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_not_get_substituted_value_when_not_maching_start_tag_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                { "Foo", "Hello (world)" }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello (world)");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_not_get_substituted_value_when_no_end_tag_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                { "Foo", "Hello $(Var what's up ?" }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello $(Var what's up ?");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_variable_when_substituted_value_is_empty_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1)" },
+                    { "Var1", string.Empty }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be(string.Empty);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_substituted_value_is_null_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string?>()
+                {
+                    { "Foo", "$(Var1)" },
+                    { "Var1", null }
+                })
+                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            Func<string> func = () => configuration["Foo"];
+
+            // Act & assert
+            func.Should().Throw<UndefinedConfigVariableException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_substituted_value_is_null_and_mismatch_fallback_default_value_delimiter_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string?>()
+                {
+                    { "Foo", "$(Var1)" },
+                    { "Var1", null }
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            Func<string> func = () => configuration["Foo"];
+
+            // Act & assert
+            func.Should().Throw<UndefinedConfigVariableException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_get_substituted_value_when_using_long_substituable_pattern_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "Hello %(env,Testo)%" },
+                    { "Testo", "world" }
+                })
+                .EnableSubstitutions("%(env,", ")%", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello world");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_when_delimited_fallback_default_value_provided_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "Hello %(env:Testo)%" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("%(", ")%", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello Testo");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_variable_when_provided_and_not_fallback_default_value_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "Hello $(Var1:Testo)" },
+                    { "Var1", "world" }
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Hello world");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_substitutableStartsWith_is_null_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            Action act1 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutions(null, ")");
+
+            // Act & assert
+            act1.Should().Throw<ArgumentException>().WithParameterName("substitutableStartsWith");
+
+            Action act2 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults(null, ")", ":", exceptionOnMissingVariables: true);
+
+            // Act & assert
+            act2.Should().Throw<ArgumentException>().WithParameterName("substitutableStartsWith");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_substitutableStartsWith_is_empty_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            Action act1 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutions("", ")");
+
+            // Act & assert
+            act1.Should().Throw<ArgumentException>().WithParameterName("substitutableStartsWith");
+
+            Action act2 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("", ")", ":", exceptionOnMissingVariables: true);
+
+            // Act & assert
+            act2.Should().Throw<ArgumentException>().WithParameterName("substitutableStartsWith");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_substitutableEndsWith_is_null_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            Action act1 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutions("$(", null);
+
+            // Act & assert
+            act1.Should().Throw<ArgumentException>().WithParameterName("substitutableEndsWith");
+
+            Action act2 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", null, ":", exceptionOnMissingVariables: true);
+
+            // Act & assert
+            act2.Should().Throw<ArgumentException>().WithParameterName("substitutableEndsWith");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_substitutableEndsWith_is_empty_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            Action act1 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutions("$(", "");
+
+            // Act & assert
+            act1.Should().Throw<ArgumentException>().WithParameterName("substitutableEndsWith");
+
+            Action act2 = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", "", ":", exceptionOnMissingVariables: true);
+
+            // Act & assert
+            act2.Should().Throw<ArgumentException>().WithParameterName("substitutableEndsWith");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_when_fallback_default_value_is_empty_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be(string.Empty);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_fallback_default_value_delimiter_is_null_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            Action act = () => builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", null, exceptionOnMissingVariables: true);
+
+            // Act & assert
+            act.Should().Throw<ArgumentNullException>().WithParameterName("fallbackDefaultValueDelimiter");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_when_fallback_default_value_delimiter_is_empty_with_substitutable_variable_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                    { "Var1:Testo", "Bar"}
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", String.Empty, exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Bar");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_throw_exception_when_fallback_default_value_delimiter_is_empty_without_substitutable_variable_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", String.Empty, exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            Func<string> func = () => configuration["Foo"];
+
+            // Act & assert
+            // Note: This assertion is NOT for ArgumentNullException nor ArgumentNullException, because it's valid to
+            //        pass an empty string delimiter constructor-wise. However, in this particular example variable
+            //        'Var1:Testo' doesn't exist, thus the UndefinedConfigVariableException exception is thrown.
+            func.Should().Throw<UndefinedConfigVariableException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_when_fallback_default_value_delimiter_is_a_space_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1 Testo)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", " ", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("Testo");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfigurationBuilderTheoryData))]
+        [Obsolete("Kept until tested method is removed")]
+        public void Should_substitute_first_occurance_of_fallback_default_value_after_delimiter_on_deprecated(Func<IConfigurationBuilder> builderGenerator)
+        {
+            var configurationBuilder = builderGenerator()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { "Foo", "$(Var1:http://example.com)" },
+                })
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":", exceptionOnMissingVariables: true);
+
+            var configuration = configurationBuilder.Build();
+
+            // Act
+            var substituted = configuration["Foo"];
+
+            substituted.Should().Be("http://example.com");
+        }
+
+        #endregion
+
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
         public void Should_get_substituted_value_when_substitution_is_in_middle(Func<IConfigurationBuilder> builderGenerator)
@@ -266,7 +1010,7 @@ namespace ConfigurationSubstitution.Tests
                 {
                     { "TestKey", "Test value {Foobar}" }
                 })
-                .EnableSubstitutions(exceptionOnMissingVariables: false);
+                .EnableSubstitutions(UnresolvedVariableBehaviour.IgnorePattern);
 
             var configuration = configurationBuilder.Build();
 
@@ -283,7 +1027,7 @@ namespace ConfigurationSubstitution.Tests
                 {
                     { "TestKey", "Test value {Foobar}" }
                 })
-                .EnableSubstitutionsWithDelimitedFallbackDefaults("{", "}", ":", false);
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("{", "}", ":", UnresolvedVariableBehaviour.IgnorePattern);
 
             var configuration = configurationBuilder.Build();
 
@@ -744,33 +1488,14 @@ namespace ConfigurationSubstitution.Tests
 
         [Theory]
         [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_throw_for_non_resolved_variable_when_keepNonResolvedVariables_is_true(Func<IConfigurationBuilder> builderGenerator)
+        public void Should_get_unsubstituted_value(Func<IConfigurationBuilder> builderGenerator)
         {
             var configurationBuilder = builderGenerator()
                 .AddInMemoryCollection(new Dictionary<string, string>()
                 {
                     { "Foo", "Counting: $(MisingVar)" }
                 })
-                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: true, keepNonResolvedVariables: true);
-
-            var configuration = configurationBuilder.Build();
-
-            // Act
-            Action act = () => _ = configuration["Foo"];
-
-            act.Should().Throw<UndefinedConfigVariableException>().WithMessage("*variable*$(MisingVar)*");
-        }
-
-        [Theory]
-        [MemberData(nameof(ConfigurationBuilderTheoryData))]
-        public void Should_get_unsubstituted_value_when_keepNonResolvedVariables_is_true(Func<IConfigurationBuilder> builderGenerator)
-        {
-            var configurationBuilder = builderGenerator()
-                .AddInMemoryCollection(new Dictionary<string, string>()
-                {
-                    { "Foo", "Counting: $(MisingVar)" }
-                })
-                .EnableSubstitutions("$(", ")", exceptionOnMissingVariables: false, keepNonResolvedVariables: true);
+                .EnableSubstitutions("$(", ")", UnresolvedVariableBehaviour.KeepPattern);
 
             var configuration = configurationBuilder.Build();
 
@@ -791,7 +1516,7 @@ namespace ConfigurationSubstitution.Tests
                     { "Var3", "three" },
                     { "Var4", "four" }
                 })
-                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":", exceptionOnMissingVariables: false, keepNonResolvedVariables: true);
+                .EnableSubstitutionsWithDelimitedFallbackDefaults("$(", ")", ":", UnresolvedVariableBehaviour.KeepPattern);
 
             var configuration = configurationBuilder.Build();
 

--- a/ConfigurationSubstitutor/ConfigurationSubstitutor.cs
+++ b/ConfigurationSubstitutor/ConfigurationSubstitutor.cs
@@ -17,15 +17,28 @@ namespace ConfigurationSubstitution
         private readonly string _endsWith;
         private readonly string _fallbackDefaultValueDelimiter;
         private Regex _findSubstitutions;
-        private readonly bool _exceptionOnMissingVariables;
-        private readonly bool _keepNonResolvedVariables;
+        private readonly UnresolvedVariableBehaviour _unresolvedVariableBehaviour;
         private ConcurrentDictionary<string, string> _fallbackDefaults;
 
+        [Obsolete]
         public ConfigurationSubstitutor(bool exceptionOnMissingVariables = true) : this("{", "}", exceptionOnMissingVariables)
         {
         }
 
-        public ConfigurationSubstitutor(string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables = true, string fallbackDefaultValueDelimiter = "", bool keepNonResolvedVariables = false)
+        public ConfigurationSubstitutor(UnresolvedVariableBehaviour unresolvedVariableBehaviour = UnresolvedVariableBehaviour.Throw) : this("{", "}", unresolvedVariableBehaviour)
+        {
+        }
+
+        [Obsolete]
+        public ConfigurationSubstitutor(string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables = true, string fallbackDefaultValueDelimiter = "")
+            : this(substitutableStartsWith,
+                  substitutableEndsWith,
+                  exceptionOnMissingVariables ? UnresolvedVariableBehaviour.Throw : UnresolvedVariableBehaviour.IgnorePattern,
+                  fallbackDefaultValueDelimiter)
+        {
+        }
+
+        public ConfigurationSubstitutor(string substitutableStartsWith, string substitutableEndsWith, UnresolvedVariableBehaviour unresolvedVariableBehaviour = UnresolvedVariableBehaviour.Throw, string fallbackDefaultValueDelimiter = "")
         {
             _startsWith = !string.IsNullOrEmpty(substitutableStartsWith) ? substitutableStartsWith : throw new ArgumentException(
                 $"Invalid substitutableStartsWith value", nameof(substitutableStartsWith));
@@ -39,8 +52,8 @@ namespace ConfigurationSubstitution
 
             _findSubstitutions = new Regex("(?<=" + escapedStart + ")(.*?)(?=" + escapedEnd + ")",
                 RegexOptions.Compiled);
-            _exceptionOnMissingVariables = exceptionOnMissingVariables;
-            _keepNonResolvedVariables = keepNonResolvedVariables;
+
+            _unresolvedVariableBehaviour = unresolvedVariableBehaviour;
         }
 
         public string GetSubstituted(IConfiguration configuration, string key)
@@ -98,14 +111,22 @@ namespace ConfigurationSubstitution
                     }
                 }
 
-                if (substitutedValue == null && _exceptionOnMissingVariables)
+                if (substitutedValue == null)
                 {
-                    throw new UndefinedConfigVariableException($"{_startsWith}{capture.Value}{_endsWith}");
-                }
+                    switch (_unresolvedVariableBehaviour)
+                    {
+                        case UnresolvedVariableBehaviour.IgnorePattern:
+                            // continue to value replacement
+                            break;
 
-                if (substitutedValue == null && _keepNonResolvedVariables)
-                {
-                    continue;
+                        case UnresolvedVariableBehaviour.KeepPattern:
+                            // continue to next captured variable
+                            continue;
+
+                        case UnresolvedVariableBehaviour.Throw:
+                        default:
+                            throw new UndefinedConfigVariableException($"{_startsWith}{capture.Value}{_endsWith}");
+                    }
                 }
 
                 value = value.Replace(_startsWith + capture.Value + _endsWith, substitutedValue);

--- a/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
+++ b/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
@@ -1,27 +1,46 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 
 namespace ConfigurationSubstitution
 {
     public static class IConfigurationBuilderExtensions
     {
-        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, bool exceptionOnMissingVariables = true)
+        [Obsolete]
+        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, bool exceptionOnMissingVariables)
         {
             return EnableSubstitutions(builder, new ConfigurationSubstitutor(exceptionOnMissingVariables));
         }
 
-        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables = true, bool keepNonResolvedVariables = false)
+        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, UnresolvedVariableBehaviour unresolvedVariableBehaviour = UnresolvedVariableBehaviour.Throw)
         {
-            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, keepNonResolvedVariables: keepNonResolvedVariables));
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(unresolvedVariableBehaviour));
+        }
+
+        [Obsolete]
+        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables)
+        {
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables));
+        }
+
+        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, UnresolvedVariableBehaviour unresolvedVariableBehaviour = UnresolvedVariableBehaviour.Throw)
+        {
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, unresolvedVariableBehaviour));
+        }
+
+        [Obsolete]
+        public static IConfigurationBuilder EnableSubstitutionsWithDelimitedFallbackDefaults(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, string fallbackDefaultValueDelimiter, bool exceptionOnMissingVariables)
+        {
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, fallbackDefaultValueDelimiter));
+        }
+
+        public static IConfigurationBuilder EnableSubstitutionsWithDelimitedFallbackDefaults(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, string fallbackDefaultValueDelimiter, UnresolvedVariableBehaviour unresolvedVariableBehaviour = UnresolvedVariableBehaviour.Throw)
+        {
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, unresolvedVariableBehaviour, fallbackDefaultValueDelimiter));
         }
 
         private static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, ConfigurationSubstitutor substitutor)
         {
             return builder.Add(new ChainedSubstitutedConfigurationSource(substitutor, builder.Build()));
-        }
-
-        public static IConfigurationBuilder EnableSubstitutionsWithDelimitedFallbackDefaults(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, string fallbackDefaultValueDelimiter, bool exceptionOnMissingVariables = true, bool keepNonResolvedVariables = false)
-        {
-            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, fallbackDefaultValueDelimiter, keepNonResolvedVariables));
         }
     }
 }

--- a/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
+++ b/ConfigurationSubstitutor/IConfigurationBuilderExtensions.cs
@@ -9,9 +9,9 @@ namespace ConfigurationSubstitution
             return EnableSubstitutions(builder, new ConfigurationSubstitutor(exceptionOnMissingVariables));
         }
 
-        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables = true)
+        public static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, bool exceptionOnMissingVariables = true, bool keepNonResolvedVariables = false)
         {
-            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables));
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, keepNonResolvedVariables: keepNonResolvedVariables));
         }
 
         private static IConfigurationBuilder EnableSubstitutions(this IConfigurationBuilder builder, ConfigurationSubstitutor substitutor)
@@ -19,9 +19,9 @@ namespace ConfigurationSubstitution
             return builder.Add(new ChainedSubstitutedConfigurationSource(substitutor, builder.Build()));
         }
 
-        public static IConfigurationBuilder EnableSubstitutionsWithDelimitedFallbackDefaults(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, string fallbackDefaultValueDelimiter, bool exceptionOnMissingVariables = true)
+        public static IConfigurationBuilder EnableSubstitutionsWithDelimitedFallbackDefaults(this IConfigurationBuilder builder, string substitutableStartsWith, string substitutableEndsWith, string fallbackDefaultValueDelimiter, bool exceptionOnMissingVariables = true, bool keepNonResolvedVariables = false)
         {
-            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, fallbackDefaultValueDelimiter));
+            return EnableSubstitutions(builder, new ConfigurationSubstitutor(substitutableStartsWith, substitutableEndsWith, exceptionOnMissingVariables, fallbackDefaultValueDelimiter, keepNonResolvedVariables));
         }
     }
 }

--- a/ConfigurationSubstitutor/UnresolvedVariableBehaviour.cs
+++ b/ConfigurationSubstitutor/UnresolvedVariableBehaviour.cs
@@ -1,0 +1,20 @@
+﻿namespace ConfigurationSubstitution
+{
+    public enum UnresolvedVariableBehaviour
+    {
+        /// <summary>
+        /// <see cref="UndefinedConfigVariableException"/> is thrown for unresolved variables
+        /// </summary>
+        Throw,
+
+        /// <summary>
+        /// Unresolved variables are ignored and replaced by empty content
+        /// </summary>
+        IgnorePattern,
+
+        /// <summary>
+        /// The pattern for substitution is kept in case of unresolved variables
+        /// </summary>
+        KeepPattern
+    }
+}


### PR DESCRIPTION
Add parameter keepNonResolvedVariables to ConfigurationSubstitutor
Update ApplySubstitution : on non resolved variable without fallback value, if configured for not throwing on missing variable, keep original setting.

Use case: I want to access my invalid settings to log them and manage the exception throwing by myself